### PR TITLE
feat: add class selection and cutscenes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For GitHub Pages deployment, upload all files in this repository to a public Git
 
 - **index.html** – Main HTML file containing the game interface and layout.
 - **style.css** – CSS stylesheet for game layout and appearance.
-- **script.js** – JavaScript file containing game logic, data, and interactive functionality.
+- **game.js** – JavaScript file containing game logic, data, and interactive functionality.
 - **README.md** – Instructions for deployment and an overview of the project.
 
 


### PR DESCRIPTION
## Summary
- add playable class selection with new `chooseClass` entry point
- trigger cutscenes, NPC dialogue and risk meter updates in story nodes
- document `game.js` as the main script file

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925a297f2883288e10fdf72f2e0370